### PR TITLE
Refactor the sync logic to preserve the bookmark folder hierarchy.

### DIFF
--- a/bookmark_sync.py
+++ b/bookmark_sync.py
@@ -10,7 +10,6 @@ SAFARI_BOOKMARKS = os.path.expanduser('~/Library/Safari/Bookmarks.plist')
 CHROME_BOOKMARKS = os.path.expanduser('~/Library/Application Support/Google/Chrome/Default/Bookmarks')
 
 BACKUP_DIR = os.path.expanduser('~/Desktop/bookmark_sync_backups')
-SYNCED_FOLDER_NAME = 'Synced'
 
 def backup_file(path):
     os.makedirs(BACKUP_DIR, exist_ok=True)
@@ -20,71 +19,126 @@ def backup_file(path):
     shutil.copy2(path, backup_path)
     print(f'Backup created: {backup_path}')
 
-def extract_safari_bookmarks(node, bookmarks=None):
-    if bookmarks is None:
-        bookmarks = []
-    if isinstance(node, dict):
+def extract_safari_bookmarks(children_list):
+    """
+    Recursively extracts bookmarks and folders from Safari's plist data
+    into a standardized format.
+    """
+    items = []
+    for node in children_list:
         if node.get('WebBookmarkType') == 'WebBookmarkTypeLeaf':
             url = node.get('URLString')
             title = node.get('URIDictionary', {}).get('title', url)
             if url:
-                bookmarks.append({'url': url, 'title': title})
-        elif node.get('Children'):
-            for child in node['Children']:
-                extract_safari_bookmarks(child, bookmarks)
-    elif isinstance(node, list):
-        for item in node:
-            extract_safari_bookmarks(item, bookmarks)
-    return bookmarks
+                items.append({'type': 'url', 'title': title, 'url': url})
+        elif node.get('WebBookmarkType') == 'WebBookmarkTypeList':
+            # This is a folder
+            folder_name = node.get('Title', '')
+            # Reading List is a special folder we want to skip
+            if folder_name == 'com.apple.ReadingList':
+                continue
+            folder_children = node.get('Children', [])
+            items.append({
+                'type': 'folder',
+                'name': folder_name,
+                'children': extract_safari_bookmarks(folder_children)
+            })
+    return items
 
-def extract_chrome_bookmarks(node, bookmarks=None):
-    if bookmarks is None:
-        bookmarks = []
-    if isinstance(node, dict):
+def extract_chrome_bookmarks(children_list):
+    """
+    Recursively extracts bookmarks and folders from Chrome's JSON data
+    into a standardized format.
+    """
+    items = []
+    for node in children_list:
         if node.get('type') == 'url':
             url = node.get('url')
             title = node.get('name', url)
             if url:
-                bookmarks.append({'url': url, 'title': title})
-        elif 'children' in node:
-            for child in node['children']:
-                extract_chrome_bookmarks(child, bookmarks)
-    elif isinstance(node, list):
-        for item in node:
-            extract_chrome_bookmarks(item, bookmarks)
-    return bookmarks
+                items.append({'type': 'url', 'title': title, 'url': url})
+        elif node.get('type') == 'folder':
+            folder_children = node.get('children', [])
+            items.append({
+                'type': 'folder',
+                'name': node.get('name', ''),
+                'children': extract_chrome_bookmarks(folder_children)
+            })
+    return items
 
-def add_safari_synced_folder(bookmarks_data, merged_bookmarks):
-    synced_folder = {
-        'Title': SYNCED_FOLDER_NAME,
-        'WebBookmarkType': 'WebBookmarkTypeList',
-        'Children': [
-            {
-                'URIDictionary': {'title': b['title']},
-                'URLString': b['url'],
+def merge_bookmark_trees(tree1, tree2):
+    """
+    Recursively merges two bookmark trees.
+
+    - Folders with the same name at the same level are merged.
+    - Bookmarks are de-duplicated by URL, with the title from the second tree winning.
+    """
+    merged_map = {}
+
+    # Add all items from the first tree
+    for item in tree1:
+        key = f"folder_{item['name']}" if item['type'] == 'folder' else item['url']
+        merged_map[key] = item
+
+    # Merge items from the second tree
+    for item in tree2:
+        key = f"folder_{item['name']}" if item['type'] == 'folder' else item['url']
+        if key in merged_map:
+            if item['type'] == 'folder':
+                # Folder exists, merge children recursively
+                existing_folder = merged_map[key]
+                merged_children = merge_bookmark_trees(
+                    existing_folder.get('children', []), item.get('children', [])
+                )
+                existing_folder['children'] = merged_children
+            else:
+                # URL exists, update title (last one wins)
+                merged_map[key]['title'] = item['title']
+        else:
+            # New item, just add it
+            merged_map[key] = item
+
+    return list(merged_map.values())
+
+def create_safari_tree(merged_tree):
+    """
+    Recursively converts the merged bookmark tree back into Safari's plist format.
+    """
+    safari_children = []
+    for item in merged_tree:
+        if item['type'] == 'url':
+            safari_children.append({
+                'URIDictionary': {'title': item['title']},
+                'URLString': item['url'],
                 'WebBookmarkType': 'WebBookmarkTypeLeaf',
-            } for b in merged_bookmarks
-        ]
-    }
-    # Add to the root level
-    bookmarks_data['Children'].append(synced_folder)
-    return bookmarks_data
+            })
+        elif item['type'] == 'folder':
+            safari_children.append({
+                'Title': item['name'],
+                'WebBookmarkType': 'WebBookmarkTypeList',
+                'Children': create_safari_tree(item.get('children', [])),
+            })
+    return safari_children
 
-def add_chrome_synced_folder(bookmarks_data, merged_bookmarks):
-    synced_folder = {
-        'type': 'folder',
-        'name': SYNCED_FOLDER_NAME,
-        'children': [
-            {
+def create_chrome_tree(merged_tree):
+    """
+    Recursively converts the merged bookmark tree back into Chrome's JSON format.
+    """
+    chrome_children = []
+    for item in merged_tree:
+        if item['type'] == 'url':
+            chrome_children.append({
                 'type': 'url',
-                'name': b['title'],
-                'url': b['url'],
-            } for b in merged_bookmarks
-        ]
-    }
-    # Add to the "bookmark_bar"
-    bookmarks_data['roots']['bookmark_bar']['children'].append(synced_folder)
-    return bookmarks_data
+                'name': item['title'],
+                'url': item['url'],
+            })
+        elif item['type'] == 'folder':
+            chrome_children.append({
+                'type': 'folder',
+                'name': item['name'],
+                'children': create_chrome_tree(item.get('children', [])),
+            })
+    return chrome_children
 
 def main():
     print('*** Please close Safari and Chrome before running this script! ***')
@@ -95,28 +149,33 @@ def main():
     backup_file(CHROME_BOOKMARKS)
 
     # Read Safari
+    print("Reading Safari bookmarks...")
     with open(SAFARI_BOOKMARKS, 'rb') as f:
         safari_data = plistlib.load(f)
-    safari_bookmarks = extract_safari_bookmarks(safari_data.get('Children', []))
+    safari_tree = extract_safari_bookmarks(safari_data.get('Children', []))
 
     # Read Chrome
+    print("Reading Chrome bookmarks...")
     with open(CHROME_BOOKMARKS, 'r') as f:
         chrome_data = json.load(f)
-    chrome_bookmarks = extract_chrome_bookmarks(chrome_data['roots'])
+    chrome_bar_children = chrome_data['roots']['bookmark_bar'].get('children', [])
+    chrome_other_children = chrome_data['roots']['other'].get('children', [])
+    chrome_tree = extract_chrome_bookmarks(chrome_bar_children + chrome_other_children)
 
-    # Merge by URL
-    url_to_bookmark = {}
-    for b in safari_bookmarks + chrome_bookmarks:
-        url_to_bookmark[b['url']] = b  # Last one wins (title from Chrome if duplicate)
-    merged_bookmarks = list(url_to_bookmark.values())
+    # Merge the two bookmark trees
+    print("Merging bookmark trees...")
+    merged_tree = merge_bookmark_trees(safari_tree, chrome_tree)
 
-    # Remove old Synced folders if present
-    safari_data['Children'] = [c for c in safari_data['Children'] if c.get('Title') != SYNCED_FOLDER_NAME]
-    chrome_data['roots']['bookmark_bar']['children'] = [c for c in chrome_data['roots']['bookmark_bar']['children'] if c.get('name') != SYNCED_FOLDER_NAME]
+    # Create the new platform-specific trees
+    new_safari_children = create_safari_tree(merged_tree)
+    new_chrome_children = create_chrome_tree(merged_tree)
 
-    # Add merged bookmarks to both
-    safari_data = add_safari_synced_folder(safari_data, merged_bookmarks)
-    chrome_data = add_chrome_synced_folder(chrome_data, merged_bookmarks)
+    # Replace the old bookmarks with the new merged tree
+    print("Updating bookmark files...")
+    safari_data['Children'] = new_safari_children
+    chrome_data['roots']['bookmark_bar']['children'] = new_chrome_children
+    chrome_data['roots']['other']['children'] = []
+    chrome_data['roots']['synced']['children'] = [] # Also clear synced folder
 
     # Write back
     with open(SAFARI_BOOKMARKS, 'wb') as f:
@@ -124,7 +183,7 @@ def main():
     with open(CHROME_BOOKMARKS, 'w') as f:
         json.dump(chrome_data, f, indent=2)
 
-    print('Bookmarks synced! Check the "Synced" folder in both browsers.')
+    print('Success! Your bookmarks have been merged and synced in both browsers.')
 
 if __name__ == '__main__':
     main() 


### PR DESCRIPTION
The original script flattened the folder structure from both Safari and Chrome, merging all bookmarks into a single "Synced" folder.

This change introduces a new, hierarchy-aware sync process:

- Bookmark extraction is now recursive, preserving the folder structure from both browsers in a standardized tree format.
- A new recursive merge function combines the two trees, merging folders with the same name and de-duplicating bookmarks by URL within each folder.
- The merged tree is then recursively converted back into the native format for each browser.
- The main function is updated to orchestrate this new process, replacing the bookmarks in each browser with the fully merged and structured hierarchy.